### PR TITLE
Fix SLA/RLA so that VF is correctly set

### DIFF
--- a/InstShift.pde
+++ b/InstShift.pde
@@ -73,7 +73,7 @@ class InstShift extends InstBase {
     switch(cmd) {
       case CMD_SLA:
       case CMD_RLA:
-        state.flagVf = state.flagCf;
+        state.flagVf = state.flagCf ^ state.flagNf;
         break;
       default: break;    
     } // 2017.01.04


### PR DESCRIPTION
This patch fixes a bug where the overflow flag (VF) is not correctly set when a value is arithmetically shifted/rotated to the left.

VF should be set if and only if the sign of the result becomes the opposite of the original value after shifted/rotated. This is covered by two cases
- CF == 0 (bit 15 of the original value was 0) and NF == 1 (bit 15 of the result is 1)
- CF == 1 (bit 15 of the original value was 1) and NF == 0 (bit 15 of the result is 0)

which can be reduced to (CF xor NF).