### PR TITLE
Modify SP and PC to vary in the 16bit range

### DIFF
--- a/InstSp.pde
+++ b/InstSp.pde
@@ -50,8 +50,8 @@ class InstPsh extends InstBase {
 
   // protected
   protected int Exec_P2 (KueState state) {
-    state.mar = state.sp - 2;
-    state.sp -= 2;
+    state.mar = (state.sp - 2) & 0xffff;
+    state.sp  = (state.sp - 2) & 0xffff;
     return RT_CONTINUE;
   }
 
@@ -81,7 +81,7 @@ class InstPop extends InstBase {
   // protected
   protected int Exec_P2 (KueState state) {
     state.mar = state.sp;
-    state.sp += 2;
+    state.sp  = (state.sp + 2) & 0xffff;
     return RT_CONTINUE;
   }
 
@@ -110,14 +110,14 @@ class InstCal extends InstBase {
 
   // protected
   protected int Exec_P2 (KueState state) {
-    state.mar = state.sp - 2;
-    state.sp  = state.sp - 2;
+    state.mar = (state.sp - 2) & 0xffff;
+    state.sp  = (state.sp - 2) & 0xffff;
     // state.IncPc();
     return RT_CONTINUE;
   }
 
   protected int Exec_P3 (KueState state) {
-    state.SetMem(state.mar, state.pc + 2);
+    state.SetMem(state.mar, (state.pc + 2) & 0xffff);
     state.mar = state.pc;
     return RT_CONTINUE;
   }
@@ -141,7 +141,7 @@ class InstRet extends InstBase {
   // protected
   protected int Exec_P2 (KueState state) {
     state.mar = state.sp;
-    state.sp += 2;
+    state.sp  = (state.sp + 2) & 0xffff;
     return RT_CONTINUE;
   }
 

--- a/KueState.pde
+++ b/KueState.pde
@@ -142,7 +142,7 @@ class KueState {
     return true;
   }
 
-  public void IncPc() { pc += 2; }  // increment : use instead of pc++
+  public void IncPc() { pc = (pc + 2) & 0xffff; }  // increment : use instead of pc++
   public void SetPc(Integer data) { pc = data; }
   public Integer GetPc() { return pc; }
   


### PR DESCRIPTION
SP and PC could become negative values (eg. SP: "0x00-2") or larger than the memory address range when manipulating the stack, so SP/PC behavior has been corrected to the same behavior as on the actual device.