### PR TITLE
Use ruechip/kuechip-assembler as assembler submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kueasm"]
 	path = kueasm
-	url = git@github.com:ks-yuzu/kueasm.git
+	url = git@github.com:ruechip/kuechip-assembler.git


### PR DESCRIPTION
現行の https://kuesim.netlify.app は別アカウントからのデプロイになっており、submodule もその設定のままになっていた。
設定いただいたデプロイジョブがコケるので、submodule の向き先を修正しておく。
(最終的にどうホスティングするかは改めて検討)